### PR TITLE
API improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ $key = $response->getTransactionReference();
 // You'll need to pass $key as well as "payerid" query parameter that you'll get from paypal redirecting back to your site
 
 $completePurchase = $gateway->completePurchase(array(
-    'purchaseId' => $key,
+    'transactionReference' => $key,
     'payerId' => $_GET['PAYERID'],
 ));
 
@@ -140,7 +140,7 @@ $response = $authorise->send();
 $id = $response->getTransactionReference();
 
 $capture = $gateway->capture(array(
-    'purchaseId' => $id,
+    'transactionReference' => $id,
     'amount' => '15.00',
 ));
 
@@ -149,7 +149,7 @@ $capture->send();
 // Or
 
 $capture = $gateway->void(array(
-    'purchaseId' => $id,
+    'transactionReference' => $id,
 ));
 
 $capture->send();
@@ -161,14 +161,14 @@ Refund
 
 ```
 $refund = $gateway->refund(array(
-    'purchaseId' => $id,
+    'transactionReference' => $id,
 ));
 
 $refund->send();
 
 // If you are refunding a capture
 $refund = $gateway->refund(array(
-    'purchaseId' => $id,
+    'transactionReference' => $id,
     'type' => 'capture'
 ));
 
@@ -176,7 +176,7 @@ $refund->send();
 
 // Partial refund
 $refund = $gateway->refund(array(
-    'purchaseId' => $id,
+    'transactionReference' => $id,
     'amount' => '10.00'
     'currency' => 'GBP'
 ));

--- a/src/Message/CaptureRequest.php
+++ b/src/Message/CaptureRequest.php
@@ -10,15 +10,15 @@ namespace Omnipay\PaypalRest\Message;
 class CaptureRequest extends AbstractPaypalRequest
 {
     /**
-     * Requires "purchaseId" parameter
+     * Requires "transactionReference" parameter
      *
      * @return string
      */
     public function getEndpoint()
     {
-        $this->validate('purchaseId');
+        $this->validate('transactionReference');
 
-        return "/payments/authorization/{$this->getPurchaseId()}/capture";
+        return "/payments/authorization/{$this->getTransactionReference()}/capture";
     }
 
     /**
@@ -27,22 +27,6 @@ class CaptureRequest extends AbstractPaypalRequest
     public function getHttpMethod()
     {
         return 'POST';
-    }
-
-    /**
-     * @return string
-     */
-    public function getPurchaseId()
-    {
-        return $this->getParameter('purchaseId');
-    }
-
-    /**
-     * @param string $value
-     */
-    public function setPurchaseId($value)
-    {
-        return $this->setParameter('purchaseId', $value);
     }
 
     /**

--- a/src/Message/PaymentApproveResponse.php
+++ b/src/Message/PaymentApproveResponse.php
@@ -29,15 +29,18 @@ class PaymentApproveResponse extends AbstractResponse implements RedirectRespons
     }
 
     /**
-     * Return true if state is "created"
+     * Return false, because this is a redirect response
      *
      * @return boolean
      */
     public function isSuccessful()
     {
-        return (parent::isSuccessful()
-            and isset($this->data['state'])
-            and $this->data['state'] === 'created');
+        return false;
+    }
+
+    public function isRedirect()
+    {
+        return $this->getLink('approval_url') !== null;
     }
 
     /**

--- a/src/Message/PaymentCompleteRequest.php
+++ b/src/Message/PaymentCompleteRequest.php
@@ -14,9 +14,9 @@ class PaymentCompleteRequest extends AbstractPaypalRequest
      */
     public function getEndpoint()
     {
-        $this->validate('purchaseId');
+        $this->validate('transactionReference');
 
-        return "/payments/payment/{$this->getPurchaseId()}/execute";
+        return "/payments/payment/{$this->getTransactionReference()}/execute";
     }
 
     /**
@@ -25,22 +25,6 @@ class PaymentCompleteRequest extends AbstractPaypalRequest
     public function getHttpMethod()
     {
         return 'POST';
-    }
-
-    /**
-     * @return string
-     */
-    public function getPurchaseId()
-    {
-        return $this->getParameter('purchaseId');
-    }
-
-    /**
-     * @param string $value
-     */
-    public function setPurchaseId($value)
-    {
-        return $this->setParameter('purchaseId', $value);
     }
 
     /**

--- a/src/Message/RefundRequest.php
+++ b/src/Message/RefundRequest.php
@@ -16,34 +16,18 @@ class RefundRequest extends AbstractPaypalRequest
      */
     public function getEndpoint()
     {
-        $this->validate('purchaseId', 'type');
+        $this->validate('transactionReference', 'type');
 
         if (false === in_array($this->getType(), array('sale', 'authorization', 'capture'))) {
             throw new InvalidRequestException('Type can only be "sale", "authorization" or "capture"');
         }
 
-        return "/payments/{$this->getType()}/{$this->getPurchaseId()}/refund";
+        return "/payments/{$this->getType()}/{$this->getTransactionReference()}/refund";
     }
 
     public function getHttpMethod()
     {
         return 'POST';
-    }
-
-    /**
-     * @return string
-     */
-    public function getPurchaseId()
-    {
-        return $this->getParameter('purchaseId');
-    }
-
-    /**
-     * @param string $value
-     */
-    public function setPurchaseId($value)
-    {
-        return $this->setParameter('purchaseId', $value);
     }
 
     /**

--- a/src/Message/VoidRequest.php
+++ b/src/Message/VoidRequest.php
@@ -14,30 +14,14 @@ class VoidRequest extends AbstractPaypalRequest
      */
     public function getEndpoint()
     {
-        $this->validate('purchaseId');
+        $this->validate('transactionReference');
 
-        return '/payments/authorization/'.$this->getPurchaseId().'/void';
+        return '/payments/authorization/'.$this->getTransactionReference().'/void';
     }
 
     public function getHttpMethod()
     {
         return 'POST';
-    }
-
-    /**
-     * @return string
-     */
-    public function getPurchaseId()
-    {
-        return $this->getParameter('purchaseId');
-    }
-
-    /**
-     * @param string $value
-     */
-    public function setPurchaseId($value)
-    {
-        return $this->setParameter('purchaseId', $value);
     }
 
     /**

--- a/tests/src/Integration/AuthoriseMockTest.php
+++ b/tests/src/Integration/AuthoriseMockTest.php
@@ -39,7 +39,8 @@ class AuthoriseMockTest extends TestCase
         $response = $request->send();
 
         $this->assertInstanceOf('Omnipay\PaypalRest\Message\PaymentApproveResponse', $response);
-        $this->assertTrue($response->isSuccessful());
+        $this->assertFalse($response->isSuccessful());
+        $this->assertTrue($response->isRedirect());
 
         $this->assertEquals('PAY-2LY017912Y929154HKQ74XPY', $response->getTransactionReference());
         $this->assertEquals('https://www.sandbox.paypal.com/cgi-bin/webscr?cmd=_express-checkout&token=EC-5SD087658M435925N', $response->getRedirectUrl());
@@ -55,7 +56,7 @@ class AuthoriseMockTest extends TestCase
 
         $request = new PaymentCompleteRequest($this->getHttpClient(), $this->getHttpRequest());
         $request->initialize(array(
-            'purchaseId' => 'PAY-2LY017912Y929154HKQ74XPY',
+            'transactionReference' => 'PAY-2LY017912Y929154HKQ74XPY',
             'payerId' => 'HVMBSS6TABKJN',
         ));
 
@@ -124,7 +125,7 @@ class AuthoriseMockTest extends TestCase
 
         $request = new CaptureRequest($this->getHttpClient(), $this->getHttpRequest());
         $request->initialize(array(
-            'purchaseId' => '9HJ30098MP9464308',
+            'transactionReference' => '9HJ30098MP9464308',
             'amount' => '3.00',
             'currency' => 'USD',
         ));
@@ -146,7 +147,7 @@ class AuthoriseMockTest extends TestCase
 
         $request = new RefundRequest($this->getHttpClient(), $this->getHttpRequest());
         $request->initialize(array(
-            'purchaseId' => '1D2800957K044141A',
+            'transactionReference' => '1D2800957K044141A',
             'amount' => '3.00',
             'currency' => 'USD',
             'type' => 'capture',
@@ -169,7 +170,7 @@ class AuthoriseMockTest extends TestCase
 
         $request = new VoidRequest($this->getHttpClient(), $this->getHttpRequest());
         $request->initialize(array(
-            'purchaseId' => '1SN458127W2399139',
+            'transactionReference' => '1SN458127W2399139',
         ));
 
         $response = $request->send();

--- a/tests/src/Integration/PurchaseMockTest.php
+++ b/tests/src/Integration/PurchaseMockTest.php
@@ -51,7 +51,8 @@ class PurchaseMockTest extends TestCase
         $response = $request->send();
 
         $this->assertInstanceOf('Omnipay\PaypalRest\Message\PaymentApproveResponse', $response);
-        $this->assertTrue($response->isSuccessful());
+        $this->assertFalse($response->isSuccessful());
+        $this->assertTrue($response->isRedirect());
 
         $this->assertEquals('PAY-7N5239784Y302191WKQ72KJI', $response->getTransactionReference());
         $this->assertEquals('https://www.sandbox.paypal.com/cgi-bin/webscr?cmd=_express-checkout&token=EC-2PU56195M4518381J', $response->getRedirectUrl());
@@ -67,7 +68,7 @@ class PurchaseMockTest extends TestCase
 
         $request = new PaymentCompleteRequest($this->getHttpClient(), $this->getHttpRequest());
         $request->initialize(array(
-            'purchaseId' => 'PAY-7N5239784Y302191WKQ72KJI',
+            'transactionReference' => 'PAY-7N5239784Y302191WKQ72KJI',
             'payerId' => 'HVMBSS6TABKJN',
         ));
 
@@ -137,7 +138,7 @@ class PurchaseMockTest extends TestCase
         $request = new RefundRequest($this->getHttpClient(), $this->getHttpRequest());
         $request->initialize(array(
             'type' => 'sale',
-            'purchaseId' => '92M94738P51857122',
+            'transactionReference' => '92M94738P51857122',
             'currency' => 'USD',
             'amount' => '1.50',
         ));

--- a/tests/src/Message/CaptureRequestTest.php
+++ b/tests/src/Message/CaptureRequestTest.php
@@ -21,7 +21,7 @@ class CaptureRequestTest extends TestCase
     public function testGetEndpoint()
     {
         $request = new CaptureRequest($this->getHttpClient(), $this->getHttpRequest());
-        $request->initialize(array('purchaseId' => 'id-12'));
+        $request->initialize(array('transactionReference' => 'id-12'));
 
         $this->assertEquals('/payments/authorization/id-12/capture', $request->getEndpoint());
     }
@@ -35,7 +35,7 @@ class CaptureRequestTest extends TestCase
 
         $this->setExpectedException(
             'Omnipay\Common\Exception\InvalidRequestException',
-            'The purchaseId parameter is required'
+            'The transactionReference parameter is required'
         );
 
         $request->getEndpoint();
@@ -52,18 +52,6 @@ class CaptureRequestTest extends TestCase
     }
 
     /**
-     * @covers ::getPurchaseId
-     * @covers ::setPurchaseId
-     */
-    public function testPurchaseId()
-    {
-        $request = new CaptureRequest($this->getHttpClient(), $this->getHttpRequest());
-
-        $this->assertSame($request, $request->setPurchaseId('purchaseid'));
-        $this->assertSame('purchaseid', $request->getPurchaseId());
-    }
-
-    /**
      * @covers ::getIsFinalCapture
      * @covers ::setIsFinalCapture
      */
@@ -71,8 +59,8 @@ class CaptureRequestTest extends TestCase
     {
         $request = new CaptureRequest($this->getHttpClient(), $this->getHttpRequest());
 
-        $this->assertSame($request, $request->setIsFinalCapture('purchaseid'));
-        $this->assertSame('purchaseid', $request->getIsFinalCapture());
+        $this->assertSame($request, $request->setIsFinalCapture('transactionReference'));
+        $this->assertSame('transactionReference', $request->getIsFinalCapture());
     }
 
     public function dataGetData()

--- a/tests/src/Message/PaymentApproveResponseTest.php
+++ b/tests/src/Message/PaymentApproveResponseTest.php
@@ -15,26 +15,15 @@ use Omnipay\PaypalRest\Message\PaymentApproveResponse;
  */
 class PaymentApproveResponseTest extends TestCase
 {
-    public function dataIsSuccessful()
-    {
-        return array(
-            array(array(), 200, false),
-            array(array('state' => 'voided'), 200, false),
-            array(array('state' => 'created'), 401, false),
-            array(array('state' => 'created'), 201, true),
-        );
-    }
-
     /**
-     * @dataProvider dataIsSuccessful
      * @covers ::isSuccessful
      */
-    public function testIsSuccessful($data, $status, $expected)
+    public function testIsSuccessful()
     {
         $request = new PaymentRequest($this->getHttpClient(), $this->getHttpRequest());
-        $response = new PaymentApproveResponse($request, $data, $status);
+        $response = new PaymentApproveResponse($request, array());
 
-        $this->assertSame($expected, $response->isSuccessful());
+        $this->assertFalse($response->isSuccessful());
     }
 
     public function dataGetLink()
@@ -92,6 +81,36 @@ class PaymentApproveResponseTest extends TestCase
         $response = new PaymentApproveResponse($request, $data);
 
         $this->assertSame($expected, $response->getLink($link));
+    }
+
+    /**
+     * @covers ::isRedirect
+     */
+    public function testIsRedirect()
+    {
+        $request = new PaymentRequest($this->getHttpClient(), $this->getHttpRequest());
+        $response = $this->getMock(
+            'Omnipay\PaypalRest\Message\PaymentApproveResponse',
+            array('getLink'),
+            array($request, array())
+        );
+
+        $response
+            ->expects($this->exactly(2))
+            ->method('getLink')
+            ->with($this->identicalTo('approval_url'))
+            ->will($this->onConsecutiveCalls(
+                null,
+                array(
+                    'href' => 'https://www.sandbox.paypal.com/cgi-bin/webscr?cmd=_express-checkout&token=EC-5SD087658M435925N',
+                    'rel' => 'approval_url',
+                    'method' => 'REDIRECT'
+                )
+            ));
+
+        $this->assertFalse($response->isRedirect());
+
+        $this->assertTrue($response->isRedirect());
     }
 
     /**

--- a/tests/src/Message/PaymentCompleteRequestTest.php
+++ b/tests/src/Message/PaymentCompleteRequestTest.php
@@ -19,14 +19,14 @@ class PaymentCompleteRequestTest extends TestCase
     {
         return array(
             array(
-                array('purchaseId' => 'id-12'),
+                array('transactionReference' => 'id-12'),
                 '/payments/payment/id-12/execute',
                 null,
             ),
             array(
                 array(),
                 null,
-                'The purchaseId parameter is required'
+                'The transactionReference parameter is required'
             ),
         );
     }
@@ -58,18 +58,6 @@ class PaymentCompleteRequestTest extends TestCase
         $request = new PaymentCompleteRequest($this->getHttpClient(), $this->getHttpRequest());
 
         $this->assertEquals('POST', $request->getHttpMethod());
-    }
-
-    /**
-     * @covers ::getPurchaseId
-     * @covers ::setPurchaseId
-     */
-    public function testPurchaseId()
-    {
-        $request = new PaymentCompleteRequest($this->getHttpClient(), $this->getHttpRequest());
-
-        $this->assertSame($request, $request->setPurchaseId('purchaseid'));
-        $this->assertSame('purchaseid', $request->getPurchaseId());
     }
 
     /**

--- a/tests/src/Message/RefundRequestTest.php
+++ b/tests/src/Message/RefundRequestTest.php
@@ -19,32 +19,32 @@ class RefundRequestTest extends TestCase
     {
         return array(
             array(
-                array('purchaseId' => 'id-12', 'type' => 'sale'),
+                array('transactionReference' => 'id-12', 'type' => 'sale'),
                 '/payments/sale/id-12/refund',
                 null,
             ),
             array(
-                array('purchaseId' => 'id-12', 'type' => 'capture'),
+                array('transactionReference' => 'id-12', 'type' => 'capture'),
                 '/payments/capture/id-12/refund',
                 null,
             ),
             array(
-                array('purchaseId' => 'id-12', 'type' => 'authorization'),
+                array('transactionReference' => 'id-12', 'type' => 'authorization'),
                 '/payments/authorization/id-12/refund',
                 null,
             ),
             array(
-                array('purchaseId' => 'id-12', 'type' => 'authorization'),
+                array('transactionReference' => 'id-12', 'type' => 'authorization'),
                 '/payments/authorization/id-12/refund',
                 null,
             ),
             array(
                 array('type' => 'sale'),
                 null,
-                'The purchaseId parameter is required'
+                'The transactionReference parameter is required'
             ),
             array(
-                array('purchaseId' => 'id-12', 'type' => 'test'),
+                array('transactionReference' => 'id-12', 'type' => 'test'),
                 null,
                 'Type can only be "sale", "authorization" or "capture"'
             ),
@@ -78,18 +78,6 @@ class RefundRequestTest extends TestCase
         $request = new RefundRequest($this->getHttpClient(), $this->getHttpRequest());
 
         $this->assertEquals('POST', $request->getHttpMethod());
-    }
-
-    /**
-     * @covers ::getPurchaseId
-     * @covers ::setPurchaseId
-     */
-    public function testPurchaseId()
-    {
-        $request = new RefundRequest($this->getHttpClient(), $this->getHttpRequest());
-
-        $this->assertSame($request, $request->setPurchaseId('purchaseid'));
-        $this->assertSame('purchaseid', $request->getPurchaseId());
     }
 
     /**

--- a/tests/src/Message/VoidRequestTest.php
+++ b/tests/src/Message/VoidRequestTest.php
@@ -21,7 +21,7 @@ class VoidRequestTest extends TestCase
     public function testGetEndpoint()
     {
         $request = new VoidRequest($this->getHttpClient(), $this->getHttpRequest());
-        $request->initialize(array('purchaseId' => 'id-12'));
+        $request->initialize(array('transactionReference' => 'id-12'));
 
         $this->assertEquals('/payments/authorization/id-12/void', $request->getEndpoint());
     }
@@ -35,7 +35,7 @@ class VoidRequestTest extends TestCase
 
         $this->setExpectedException(
             'Omnipay\Common\Exception\InvalidRequestException',
-            'The purchaseId parameter is required'
+            'The transactionReference parameter is required'
         );
 
         $request->getEndpoint();
@@ -49,18 +49,6 @@ class VoidRequestTest extends TestCase
         $request = new VoidRequest($this->getHttpClient(), $this->getHttpRequest());
 
         $this->assertEquals('POST', $request->getHttpMethod());
-    }
-
-    /**
-     * @covers ::getPurchaseId
-     * @covers ::setPurchaseId
-     */
-    public function testPurchaseId()
-    {
-        $request = new VoidRequest($this->getHttpClient(), $this->getHttpRequest());
-
-        $this->assertSame($request, $request->setPurchaseId('purchaseid'));
-        $this->assertSame('purchaseid', $request->getPurchaseId());
     }
 
     /**


### PR DESCRIPTION
Removing purchaseId in favour of the standard transactionReference. Adding proper redirect logic in PaymentApproveResponse
