### PR TITLE
Fixed typographical error, changed anouncement to announcement in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ If you are having general issues with Omnipay, we suggest posting on
 [Stack Overflow](http://stackoverflow.com/). Be sure to add the
 [omnipay tag](http://stackoverflow.com/questions/tagged/omnipay) so it can be easily found.
 
-If you want to keep up to date with release anouncements, discuss ideas for the project,
+If you want to keep up to date with release announcements, discuss ideas for the project,
 or ask more detailed questions, there is also a [mailing list](https://groups.google.com/forum/#!forum/omnipay) which
 you can subscribe to.
 


### PR DESCRIPTION
@clippings, I've corrected a typographical error in the documentation of the [omnipay-paypal](https://github.com/clippings/omnipay-paypal) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.